### PR TITLE
Add default clause on createFoldObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+-   Default clause on `createFoldObject`
+
+### Changed
+
+-   dependencies updates
+
 ## [1.0.4]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -12,65 +12,25 @@ be used in standard Javascript apps.
 First, install the library:
 
 ```bash
-yarn add @iadvize-oss/foldable-helpers
+npm add @iadvize-oss/foldable-helpers
 ```
 
 [📖 Documentation](https://iadvize.github.io/foldable-helpers-library/)
 
-## Classic fold - `createFold`
+## Named fold - `createFoldObject`
 
 You have a sum type and the type guards for each of the types. For example:
 
 ```ts
 type T = A | B | C;
 
-function isA(t: T): t is A { ... };
-function isB(t: T): t is B { ... };
-function isC(t: T): t is C { ... };
+function isA(t: T): t is A { ... }
+function isB(t: T): t is B { ... }
+function isC(t: T): t is C { ... }
 ```
 
-To create a fold function to fold on `T`, use `createFold`
-
-```ts
-import { pipe } from 'fp-ts/es6/pipeable';
-
-import { createFold } from '@iadvize-oss/foldable-helpers';
-
-const foldOnT = createFold(isA, isB, isC);
-
-const t: T = ...;
-
-pipe(
-  t,
-  foldOnT(
-    (tbis) => console.log('executed when t is A', { tbis }),
-    (tbis) => console.log('executed when t is B', { tbis }),
-    (tbis) => console.log('executed when t is C', { tbis }),
-  ),
-);
-```
-
-## Named fold - `createFoldObject`
-
-Classic fold is very useful but could become hard to read when we have more than
-3-4 types to fold on.
-Because we don't have named parameters in JS/Typescript, we have to use
-something else.
-
-You still have a sum type and the type guards for each of the types.
-For example:
-
-```ts
-type T = A | B | C;
-
-function isA(t: T): t is A { ... };
-function isB(t: T): t is B { ... };
-function isC(t: T): t is C { ... };
-```
-
-To create a named fold function to fold on `T` without loosing readability,
-use `createFoldObject`. You choose the name of each fold function by passing
-an object.
+To create a named fold function to fold on `T`, use `createFoldObject`. You
+choose the name of each fold function by passing an object.
 
 ```ts
 import { pipe } from 'fp-ts/es6/pipeable';
@@ -95,10 +55,48 @@ pipe(
 );
 ```
 
+## Classic fold - `createFold`
+
+You have a sum type and the type guards for each of the types. For example:
+
+```ts
+type T = A | B | C;
+
+function isA(t: T): t is A { ... }
+function isB(t: T): t is B { ... }
+function isC(t: T): t is C { ... }
+```
+
+To create a fold function to fold on `T`, use `createFold`
+
+```ts
+import { pipe } from 'fp-ts/es6/pipeable';
+
+import { createFold } from '@iadvize-oss/foldable-helpers';
+
+const foldOnT = createFold(isA, isB, isC);
+
+const t: T = ...;
+
+pipe(
+  t,
+  foldOnT(
+    (tbis) => console.log('executed when t is A', { tbis }),
+    (tbis) => console.log('executed when t is B', { tbis }),
+    (tbis) => console.log('executed when t is C', { tbis }),
+  ),
+);
+```
+
+Classic fold is very useful but could become hard to read when we have more than
+3-4 types to fold on. You probably want to use `createFoldObject` in that case.
+
+
 ## `combineGuards`
 
-When using fold you will probably encounter cases where a type is a combination (union) of different guards
-to reduce the boilerplate having to write each combination by hand you can use the `combineGuards` helper.
+When using fold you will probably encounter cases where a type is a combination
+(union) of different guards. Oo reduce the boilerplate of having to write each
+combination by hand you can use the `combineGuards` helper.
 
 ```ts
 type A = { a: string };
@@ -113,16 +111,19 @@ const isTypeB = (value: any): value is B =>
 const oldIsTypeAAndB = (value: any): value is A & B =>
     isTypeA(value) && isTypeB(value);
 
-const isTypeAAndB = combineGuards(isTypeA, isTypeB); // :(t: any): t is A & B => boolean
+const isTypeAAndB = combineGuards(isTypeA, isTypeB);
+// (t: any): t is A & B => boolean
 ```
 
 ## `not`
 
-When using createFold you **need to make sure that each guard mutually excludes the others** but it can sometimes be painfull if one type depends on another, therefore we let you use the `not` operator to exclude a guard
+When using createFold you **need to make sure that each guard mutually excludes
+the others** but it can sometimes be painfull if one type depends on another,
+therefore we let you use the `not` operator to exclude a guard
 
 ```ts
-type TypeA = { a: string};
-type TypeB = { a: 'test'};
+type TypeA = { a: string };
+type TypeB = { a: 'test' };
 
 const isTypeA = (value: {a: unknown}): value is TypeA => typeof value.a === 'string';
 const isTypeB = (value: TypeA): value is TypeB => value.a === 'test';

--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ npm add @iadvize-oss/foldable-helpers
 You have a sum type and the type guards for each of the types. For example:
 
 ```ts
-type T = A | B | C;
+type T = A | B | C | D;
 
 function isA(t: T): t is A { ... }
 function isB(t: T): t is B { ... }
 function isC(t: T): t is C { ... }
+function isD(t: T): t is D { ... }
 ```
 
 To create a named fold function to fold on `T`, use `createFoldObject`. You
@@ -40,7 +41,8 @@ import { createFoldObject } from '@iadvize-oss/foldable-helpers';
 const foldOnT = createFoldObject({
   onA: isA,
   onB: isB,
-  onC: isC
+  onC: isC,
+  onD: isD,
 });
 
 const t: T = ...;
@@ -51,9 +53,27 @@ pipe(
     onA: (tbis) => console.log('executed when t is A', { tbis }),
     onB: (tbis) => console.log('executed when t is B', { tbis }),
     onC: (tbis) => console.log('executed when t is C', { tbis }),
+    onD: (tbis) => console.log('executed when t is D', { tbis }),
   }),
 );
 ```
+
+### Default clause
+
+You can use `_` as a "catch all" clause if you don't want to handle all types
+independently.
+
+```ts
+pipe(
+  t,
+  foldOnT({
+    onA: (tbis) => console.log('executed when t is A', { tbis }),
+    onB: (tbis) => console.log('executed when t is B', { tbis }),
+    _:   (tbis) => console.log('executed when t is not A nor B', { tbis }),
+  }),
+);
+```
+
 
 ## Classic fold - `createFold`
 

--- a/src/createFoldObject.ts
+++ b/src/createFoldObject.ts
@@ -1,9 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import * as ArrayFP from 'fp-ts/es6/Array';
 import * as Either from 'fp-ts/es6/Either';
+import * as RecordFP from 'fp-ts/es6/Record';
 import { pipe } from 'fp-ts/es6/pipeable';
+import { identity } from 'fp-ts/es6/function';
 
 import { Guard, Func } from './types';
+
+const DEFAULT_CLAUSE = '_';
 
 type Guards<TypesRecord extends Record<string, any>> = {
   [key in keyof TypesRecord]: Guard<any, TypesRecord[key]>;
@@ -12,32 +16,77 @@ type Guards<TypesRecord extends Record<string, any>> = {
 export function createFoldObject<TypesRecord extends Record<string, any>>(
   guards: Guards<TypesRecord>,
 ) {
-  type FoldFunctions<TypesRecord extends Record<string, any>, R> = {
+  type FullFoldFunctions<R> = {
     [key in keyof TypesRecord]: Func<TypesRecord[key], R>;
   };
 
-  type Instance<
-    TypesRecord extends Record<string, any>
-  > = TypesRecord[keyof TypesRecord & string];
+  type PartialFoldFunctions<R> = Partial<FullFoldFunctions<R>>;
 
-  return function fold<R>(funcs: FoldFunctions<TypesRecord, R>) {
-    return (s: Instance<TypesRecord>): R => {
-      const keys = Object.keys(guards);
+  type OmittedTypesRecord<R> = Omit<TypesRecord, keyof PartialFoldFunctions<R>>;
+
+  type OmittedTypesInstance<R> = OmittedTypesRecord<R>[keyof OmittedTypesRecord<
+    R
+  >];
+
+  type PartialFoldFunctionsWithDefault<R> = PartialFoldFunctions<R> & {
+    _: Func<OmittedTypesInstance<R>, R>;
+  };
+
+  type FoldFunctions<R> =
+    | PartialFoldFunctionsWithDefault<R>
+    | FullFoldFunctions<R>;
+
+  type Instance = TypesRecord[keyof TypesRecord & string];
+
+  return function fold<R>(funcs: FoldFunctions<R>) {
+    return (s: Instance): R => {
+      const keys = RecordFP.keys(guards);
 
       return pipe(
         keys,
         ArrayFP.findFirst(key => guards[key](s)),
         Either.fromOption(() => new Error(`No guard found to fold ${s}`)),
+        Either.chain(key => {
+          if (key in funcs) {
+            const func = funcs[key];
+
+            if (typeof func !== 'function') {
+              return Either.left(
+                new Error(`"${key}" clause should be a function`),
+              );
+            }
+
+            return Either.right(func(s));
+          }
+
+          if (DEFAULT_CLAUSE in funcs) {
+            const func = funcs[DEFAULT_CLAUSE];
+
+            if (typeof func !== 'function') {
+              return Either.left(
+                new Error(`"${DEFAULT_CLAUSE}" clause should be a function`),
+              );
+            }
+
+            // s is not refined magically by TS so we have to force the type
+            const localS = s as OmittedTypesInstance<R>;
+
+            return Either.right(func(localS));
+          }
+
+          return Either.left(
+            new Error(`No "${key}" nor "_" clause passed to fold`),
+          );
+        }),
         Either.fold(
-          // if no key found, we throw error, guards are broken
+          // if no function found, we throw error, guards or fold clauses are
+          // broken
           error => {
             throw error;
           },
-          // we found a key, we return the result of the good function
-          // applied to s
-          key => {
-            return funcs[key](s);
-          },
+          // we found a function, we return the result of the function applied
+          // to the given instance
+          identity,
         ),
       );
     };

--- a/src/createFoldObject.ts
+++ b/src/createFoldObject.ts
@@ -1,34 +1,34 @@
-import { findFirst } from 'fp-ts/es6/Array';
-import { fromOption, fold } from 'fp-ts/es6/Either';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as ArrayFP from 'fp-ts/es6/Array';
+import * as Either from 'fp-ts/es6/Either';
 import { pipe } from 'fp-ts/es6/pipeable';
 
 import { Guard, Func } from './types';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Guards<TypesRecord extends Record<string, any>> = {
+  [key in keyof TypesRecord]: Guard<any, TypesRecord[key]>;
+};
+
 export function createFoldObject<TypesRecord extends Record<string, any>>(
-  guards: {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    [key in keyof TypesRecord]: Guard<any, TypesRecord[key]>;
-  },
+  guards: Guards<TypesRecord>,
 ) {
-  return function<R>(
-    funcs: {
-      [key in keyof TypesRecord]: Func<TypesRecord[key], R>;
-    },
-  ) {
-    // need & string here to filter number and symbol
-    type Names = keyof TypesRecord & string;
+  type FoldFunctions<TypesRecord extends Record<string, any>, R> = {
+    [key in keyof TypesRecord]: Func<TypesRecord[key], R>;
+  };
 
-    type AllTypes = TypesRecord[Names];
+  type Instance<
+    TypesRecord extends Record<string, any>
+  > = TypesRecord[keyof TypesRecord & string];
 
-    return (s: AllTypes): R => {
+  return function fold<R>(funcs: FoldFunctions<TypesRecord, R>) {
+    return (s: Instance<TypesRecord>): R => {
       const keys = Object.keys(guards);
 
       return pipe(
         keys,
-        findFirst(key => guards[key](s)),
-        fromOption(() => new Error(`No guard found to fold ${s}`)),
-        fold(
+        ArrayFP.findFirst(key => guards[key](s)),
+        Either.fromOption(() => new Error(`No guard found to fold ${s}`)),
+        Either.fold(
           // if no key found, we throw error, guards are broken
           error => {
             throw error;

--- a/tests/__snapshots__/createFoldObject.test.ts.snap
+++ b/tests/__snapshots__/createFoldObject.test.ts.snap
@@ -1,3 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`createFoldObject created fold should throw if clause function found 1`] = `"No \\"type2\\" nor \\"_\\" clause passed to fold"`;
+
+exports[`createFoldObject created fold should throw if clause is not a function 1`] = `"\\"type2\\" clause should be a function"`;
+
+exports[`createFoldObject created fold should throw if default clause is not a function 1`] = `"\\"_\\" clause should be a function"`;
+
 exports[`createFoldObject created fold should throw if no guard found 1`] = `"No guard found to fold [object Object]"`;

--- a/tests/createFoldObject.test.ts
+++ b/tests/createFoldObject.test.ts
@@ -106,4 +106,98 @@ describe('createFoldObject', () => {
 
     expect(funcThatWillThrow).toThrowErrorMatchingSnapshot();
   });
+
+  it('created fold should accept a default clause', () => {
+    const fold = createFoldObject({
+      type1: isType1,
+      type2: isType2,
+      type3: isType3,
+      type4: isType4,
+      type5: isType5,
+      type6: isType6,
+    });
+
+    const result1 = pipe(
+      { tag: 1 },
+      fold({
+        type1: () => 'result1',
+        _: () => 'default',
+      }),
+    );
+
+    expect(result1).toEqual(`result1`);
+
+    const result2 = pipe(
+      { tag: 2 },
+      fold({
+        type1: () => 'result1',
+        _: () => 'default',
+      }),
+    );
+
+    expect(result2).toEqual(`default`);
+  });
+
+  it('created fold should throw if clause function found', () => {
+    const fold = createFoldObject({
+      type1: isType1,
+      type2: isType2,
+    });
+
+    const tag = { tag: 2 };
+    const someFunc = fold<{ tag: number }>({
+      type1: identity,
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore - testing behavior without type safety
+      type3: identity,
+    });
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const funcThatWillThrow = () => someFunc(tag);
+
+    expect(funcThatWillThrow).toThrowErrorMatchingSnapshot();
+  });
+
+  it('created fold should throw if clause is not a function', () => {
+    const fold = createFoldObject({
+      type1: isType1,
+      type2: isType2,
+    });
+
+    const tag = { tag: 2 };
+    const someFunc = fold<{ tag: number }>({
+      type1: identity,
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore - testing behavior without type safety
+      type2: 'toto',
+    });
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const funcThatWillThrow = () => someFunc(tag);
+
+    expect(funcThatWillThrow).toThrowErrorMatchingSnapshot();
+  });
+
+  it('created fold should throw if default clause is not a function', () => {
+    const fold = createFoldObject({
+      type1: isType1,
+      type2: isType2,
+    });
+
+    const tag = { tag: 2 };
+    const someFunc = fold<{ tag: number }>({
+      type1: identity,
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore - testing behavior without type safety
+      _: 'toto',
+    });
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const funcThatWillThrow = () => someFunc(tag);
+
+    expect(funcThatWillThrow).toThrowErrorMatchingSnapshot();
+  });
 });


### PR DESCRIPTION
Sometimes, we don't want to handle each type of an union independently while folding.

Languages that have pattern matching built-in usually offer a "catch all" clause like this:

```scala
val x: Int = 2

x match {
  case 0 => "zero"
  case 1 => "one"
  case 2 => "two"
  case _ => "other"
}
```

This PR adds the same functionality on the `createFoldObject` helper.

```ts
import { createFoldObject } from '@iadvize-oss/foldable-helpers';

const foldOnT = createFoldObject({
  onA: isA,
  onB: isB,
  onC: isC,
  onD: isD,
});

pipe(
  t,
  foldOnT({
    onA: (tbis) => console.log('executed when t is A', { tbis }),
    onB: (tbis) => console.log('executed when t is B', { tbis }),
    _:   (tbis) => console.log('executed when t is not A nor B', { tbis }),
  }),
);

```