### PR TITLE
NO-TICKET: more flexible `createFold` and `createFoldObject` to pass already refined data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+-   More flexible `createFold` and `createFoldObject` signature that allow users
+    to pass already refined data and not loose the refining
+
 ## [2.1.1]
 
 ### Fixed

--- a/src/createFold.ts
+++ b/src/createFold.ts
@@ -1,22 +1,35 @@
-import { zip, findFirst } from 'fp-ts/es6/Array';
-import { fromOption, fold } from 'fp-ts/es6/Either';
+import * as ArrayFP from 'fp-ts/es6/Array';
+import * as Either from 'fp-ts/es6/Either';
 import { pipe } from 'fp-ts/es6/pipeable';
 
-import { Funcify, Guardify } from './types';
+import { Guard, Func } from './types';
+
+export type Funcify<T, R> = { [P in keyof T]: Func<T[P], R> };
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Guardify<T> = { [P in keyof T]: Guard<any, T[P]> };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function createFold<Types extends any[]>(...guards: Guardify<Types>) {
-  return function <R>(...funcs: Funcify<Types, R>) {
-    type AllTypes = Types[number];
+  type AllTypes = Types[number];
 
+  function fold<R>(...funcs: Funcify<Types, R>): (s: AllTypes) => R;
+  function fold<R, S extends AllTypes>(
+    ...funcs: Funcify<
+      {
+        [key in keyof Types]: Extract<Types[key], S>;
+      },
+      R
+    >
+  ): (s: S) => R;
+  function fold<R>(...funcs: Funcify<Types, R>) {
     return (s: AllTypes): R => {
-      const guardsWithFuncs = zip(guards, funcs);
+      const guardsWithFuncs = ArrayFP.zip(guards, funcs);
 
       return pipe(
         guardsWithFuncs,
-        findFirst(([guard]) => guard(s)),
-        fromOption(() => new Error(`No guard found to fold ${s}`)),
-        fold(
+        ArrayFP.findFirst(([guard]) => guard(s)),
+        Either.fromOption(() => new Error(`No guard found to fold ${s}`)),
+        Either.fold(
           // if no guard found, we throw error, guards are broken
           (error) => {
             throw error;
@@ -30,5 +43,7 @@ export function createFold<Types extends any[]>(...guards: Guardify<Types>) {
         ),
       );
     };
-  };
+  }
+
+  return fold;
 }

--- a/src/createFoldObject.ts
+++ b/src/createFoldObject.ts
@@ -1,5 +1,5 @@
-import { findFirst } from 'fp-ts/es6/Array';
-import { fromOption, fold } from 'fp-ts/es6/Either';
+import * as ArrayFP from 'fp-ts/es6/Array';
+import * as Either from 'fp-ts/es6/Either';
 import { pipe } from 'fp-ts/es6/pipeable';
 
 import { Guard, Func } from './types';
@@ -13,24 +13,33 @@ export function createFoldObject<
     [key in keyof TypesRecord]: Guard<any, TypesRecord[key]>;
   },
 ) {
-  return function <R>(
+  type Names = keyof TypesRecord;
+
+  type AllTypes = TypesRecord[Names];
+
+  function fold<R>(
+    funcs: {
+      [key in keyof TypesRecord]: Func<TypesRecord[key], R>;
+    },
+  ): (s: AllTypes) => R;
+  function fold<R, S extends AllTypes>(
+    funcs: {
+      [key in keyof TypesRecord]: Func<Extract<S, TypesRecord[key]>, R>;
+    },
+  ): (s: S) => R;
+  function fold<R>(
     funcs: {
       [key in keyof TypesRecord]: Func<TypesRecord[key], R>;
     },
   ) {
-    // need & string here to filter number and symbol
-    type Names = keyof TypesRecord;
-
-    type AllTypes = TypesRecord[Names];
-
     return (s: AllTypes): R => {
       const keys = Object.keys(guards) as Names[];
 
       return pipe(
         keys,
-        findFirst((key) => guards[key](s)),
-        fromOption(() => new Error(`No guard found to fold ${s}`)),
-        fold(
+        ArrayFP.findFirst((key) => guards[key](s)),
+        Either.fromOption(() => new Error(`No guard found to fold ${s}`)),
+        Either.fold(
           // if no key found, we throw error, guards are broken
           (error) => {
             throw error;
@@ -43,5 +52,7 @@ export function createFoldObject<
         ),
       );
     };
-  };
+  }
+
+  return fold;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,3 @@
 export type Guard<A, B extends A> = (a: A) => a is B;
 
 export type Func<S, R> = (s: S) => R;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type Guardify<T> = { [P in keyof T]: Guard<any, T[P]> };
-export type Funcify<T, R> = { [P in keyof T]: Func<T[P], R> };


### PR DESCRIPTION
> Ticket NO-TICKET